### PR TITLE
added edl command to symlink a package folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,14 @@ and you can provide interactive answers.
     # Release a new minor version
     edi ember release --minor
 
+### edl
+`edl` is your friend when developing addons. It provides a replacement for `nmp link` that works in docker-ember. 
+
+    # Create a global symlink of your addon
+		cd your-ember-addon
+		edl
+		# Use that addon in another project
+		cd your-ember-project
+		edl your-ember-addon
+
+*Note*: `edl` assumes `edi` is available on your PATH

--- a/bin/edl
+++ b/bin/edl
@@ -1,0 +1,20 @@
+#!/bin/bash
+# This is the command to use when you would normally run "npm link"
+
+function jsonval {
+    temp=`echo $json | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w $prop | cut -d":" -f2| sed -e 's/^ *//g' -e 's/ *$//g' `
+    echo ${temp##*|}
+}
+
+if [ ! -f package.json ]; then
+	 echo "Error: "
+	 echo "  package.json not found, please run in the root directory of your addon"
+	 exit -1
+fi
+prop=name
+json=`cat package.json`
+ln -s `pwd` /home/`whoami`/.local/lib/node_modules/`jsonval`
+if [ $? == 0 ];then 
+  echo "created symlink for '`jsonval`' in node_modules"
+  echo "you can now add this addon to your project using 'edi npm link `jsonval`'"
+fi

--- a/bin/edl
+++ b/bin/edl
@@ -1,20 +1,51 @@
 #!/bin/bash
 # This is the command to use when you would normally run "npm link"
 
+NODE_M_PATH="/home/`whoami`/.local/lib/node_modules/"
+PACKAGE_FILE="package.json"
+
+# make sure path is available
+mkdir -p $NODE_M_PATH
+
+# supporting function to extract json values
 function jsonval {
     temp=`echo $json | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w $prop | cut -d":" -f2| sed -e 's/^ *//g' -e 's/ *$//g' `
     echo ${temp##*|}
 }
 
-if [ ! -f package.json ]; then
+# supporting function to verify we're on the right path
+function verify_path {
+if [ ! -f $PACKAGE_FILE ]; then
 	 echo "Error: "
 	 echo "  package.json not found, please run in the root directory of your addon"
 	 exit -1
 fi
+}
+
+# supporting function to create symlinks
+function npm_link {
 prop=name
-json=`cat package.json`
-ln -s `pwd` /home/`whoami`/.local/lib/node_modules/`jsonval`
+json=`cat $PACKAGE_FILE`
+ln -s `pwd` $NODE_M_PATH`jsonval`
 if [ $? == 0 ];then 
   echo "created symlink for '`jsonval`' in node_modules"
-  echo "you can now add this addon to your project using 'edi npm link `jsonval`'"
+  echo "you can now add this addon to your project using 'edl `jsonval`'"
 fi
+}
+
+
+if [[ $# -ge 2 || $1 == "-h" ]];then
+		echo "usage: "
+		echo " edl  (create a symlink to package)"
+		echo " edl [package-name] (use a local symlinked package)"
+		echo " edl -h (this help text)"
+		exit 1;
+fi
+
+if [[ -n $1 ]];then
+		edi npm link $1		
+else
+		verify_path && npm_link
+fi
+
+

--- a/bin/edl
+++ b/bin/edl
@@ -1,3 +1,4 @@
+
 #!/bin/bash
 # This is the command to use when you would normally run "npm link"
 
@@ -15,22 +16,22 @@ function jsonval {
 
 # supporting function to verify we're on the right path
 function verify_path {
-if [ ! -f $PACKAGE_FILE ]; then
-	 echo "Error: "
-	 echo "  package.json not found, please run in the root directory of your addon"
-	 exit -1
-fi
+  if [ ! -f $PACKAGE_FILE ]; then
+	   echo "Error: "
+	   echo "  package.json not found, please run in the root directory of your addon"
+	   exit -1
+  fi
 }
 
 # supporting function to create symlinks
 function npm_link {
-prop=name
-json=`cat $PACKAGE_FILE`
-ln -s `pwd` $NODE_M_PATH`jsonval`
-if [ $? == 0 ];then 
-  echo "created symlink for '`jsonval`' in node_modules"
-  echo "you can now add this addon to your project using 'edl `jsonval`'"
-fi
+  prop=name
+  json=`cat $PACKAGE_FILE`
+  ln -s -T  `pwd` "$NODE_M_PATH"`jsonval`
+  if [ $? == 0 ];then 
+    echo "created symlink for '`jsonval`' in node_modules"
+    echo "you can now add this addon to your project using 'edl `jsonval`'"
+  fi
 }
 
 


### PR DESCRIPTION
edl is a replacement for npm link. Just use edl when you would normally
run `npm link`. To use the linked package you can run `edi npm link package-name`
