### PR TITLE
added option to provide ssh_keys

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -30,6 +30,16 @@ then
     done
 fi
 
+# mount ssh keys folder
+if [ -n "$SSH_FOLDER" ]
+then
+    echo "ed will mount ssh keys folder $SSH_FOLDER"
+    linked_volumes="$linked_volumes --volume $SSH_FOLDER:/root/.ssh:ro "
+
+    # see issue https://github.com/ember-cli-deploy/ember-cli-deploy-revision-data/issues/52 for deploying in ember-cli-deploy context
+    linked_volumes="$linked_volumes -e GIT_DISCOVERY_ACROSS_FILESYSTEM=1 "
+fi
+
 docker run --rm \
        --volume `pwd`:/app/ \
        --volume /app/tmp \

--- a/bin/edi
+++ b/bin/edi
@@ -28,6 +28,16 @@ then
     done
 fi
 
+# mount ssh keys folder
+if [ -n "$SSH_FOLDER" ]
+then
+    echo "ed will mount ssh keys folder $SSH_FOLDER"
+    linked_volumes="$linked_volumes --volume $SSH_FOLDER:/root/.ssh:ro "
+
+    # see issue https://github.com/ember-cli-deploy/ember-cli-deploy-revision-data/issues/52 for deploying in ember-cli-deploy context
+    linked_volumes="$linked_volumes -e GIT_DISCOVERY_ACROSS_FILESYSTEM=1 "
+fi
+
 docker run --rm \
        -it \
        --volume `pwd`:/app/ \


### PR DESCRIPTION
For ember-cli-deploys over ssh, we needed a way to provide ed with ssh keys. 
If this is ok, I'll update the template files too.