### PR TITLE
Check if $SSH_AUTH_SOCK is set before using it as an argument for dirname

### DIFF
--- a/bin/ed
+++ b/bin/ed
@@ -138,6 +138,9 @@ edi_calculate_ssh_agent_options() {
             ssh-add
         fi
         ssh_agent_options="$(pinata-ssh-mount)"
+    elif [ -z "$SSH_AUTH_SOCK" ]; then
+        echo "\$SSH_AUTH_SOCK not set! Is your SSH agent running?"
+        exit
     else
         # see https://gist.github.com/d11wtq/8699521
         ssh_agent_options="--volume $(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK) \

--- a/bin/edi
+++ b/bin/edi
@@ -136,6 +136,9 @@ edi_calculate_ssh_agent_options() {
             ssh-add
         fi
         ssh_agent_options="$(pinata-ssh-mount)"
+    elif [ -z "$SSH_AUTH_SOCK" ]; then
+        echo "\$SSH_AUTH_SOCK not set! Is your SSH agent running?"
+        exit
     else
         # see https://gist.github.com/d11wtq/8699521
         ssh_agent_options="--volume $(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK) \

--- a/bin/eds
+++ b/bin/eds
@@ -136,6 +136,9 @@ edi_calculate_ssh_agent_options() {
             ssh-add
         fi
         ssh_agent_options="$(pinata-ssh-mount)"
+    elif [ -z "$SSH_AUTH_SOCK" ]; then
+        echo "\$SSH_AUTH_SOCK not set! Is your SSH agent running?"
+        exit
     else
         # see https://gist.github.com/d11wtq/8699521
         ssh_agent_options="--volume $(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK) \

--- a/support-scripts
+++ b/support-scripts
@@ -122,6 +122,9 @@ edi_calculate_ssh_agent_options() {
             ssh-add
         fi
         ssh_agent_options="$(pinata-ssh-mount)"
+    elif [ -z "$SSH_AUTH_SOCK" ]; then
+        echo "\$SSH_AUTH_SOCK not set! Is your SSH agent running?"
+        exit
     else
         # see https://gist.github.com/d11wtq/8699521
         ssh_agent_options="--volume $(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK) \


### PR DESCRIPTION
On Linux, if your SSH agent isn't running, the `SSH_AUTH_SOCK` environment variable will not be set, resulting in a "missing operand" error from dirname.

This MR adds a warning if the variable is not set and exits the script