### PR TITLE
edl sometimes leaves a random broken symlink in the target dir

### DIFF
--- a/bin/edl
+++ b/bin/edl
@@ -91,7 +91,7 @@ function npm_link_package {
         rm -rf node_modules/$name
     fi
     mkdir -p node_modules/$scope
-    edi "ln -fs /usr/lib/node_modules/$name /app/node_modules/$name"
+    edi "ln -s /usr/lib/node_modules/$name /app/node_modules/$name"
 }
 
 function show_usage {

--- a/bin/edl
+++ b/bin/edl
@@ -81,12 +81,17 @@ function npm_unlink {
 function npm_link_package {
     name=$1
     scope=`get_scope $name`
-    if [  -e node_modules/$name ];then
+    if [[ -L node_modules/$name ]]
+    then
+        echo "removing previously linked module"
+        rm node_modules/$name
+    fi
+    if [ -e node_modules/$name ];then
         echo "removing installed module"
         rm -rf node_modules/$name
     fi
     mkdir -p node_modules/$scope
-    edi "ln -s /usr/lib/node_modules/$name /app/node_modules/$name"
+    edi "ln -fs /usr/lib/node_modules/$name /app/node_modules/$name"
 }
 
 function show_usage {


### PR DESCRIPTION
Lets define some terms:
target: the dependency which we want to link
host: the project which needs the linked dependency
In the following, target and host represent the names of their respective projects, never the literals "target" or "host"

steps to reproduce:
- nuke node_modules in both host and target
- `ed npm install` in target
- `edl` in target
- `ed npm install` in host
- `edl target` in host

so far so good, things are correctly linked
but now:
- `edl target` in host once again

I expect this to do nothing, or at least error out or something. Instead, we get a symlink called `target` inside the project dir of target. It points to, in my case, `/usr/lib/node_modules/target`. I assume this is the path inside the docker container that leaked out somehow.

This leads to very confusing behavior on the host side, namely the build breaking although no code changes have occurred. 
