### PR TITLE
Bump npm to v8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update; apt-get -y install
 RUN wget -qO- https://deb.nodesource.com/setup_16.x > node_setup.sh
 RUN bash node_setup.sh
 RUN apt-get -y install nodejs
-RUN npm install -g npm@7.18.1
+RUN npm install -g npm@8.3.0
 # Install bower
-RUN npm install -g bower@1.8.12
+RUN npm install -g bower@1.8.13
 RUN echo '{ "allow_root": true }' > /root/.bowerrc
 # Install yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ VERSION="3.15.1"
 
 ## Additional notes
 
-### On linux
+### On Linux
 
 By default `ed*` commands run as root in the docker container, this means newly created files will be owned as root as well. To avoid this you can use user namespaces to map the container's root user to your own user. This requires some minimal configuration.
 
@@ -143,6 +143,19 @@ fi
 #### 2. Support the ssh-agent
 
 The ssh-agent's socket can't be shared with Docker for Mac at the time of writing.  A common workaround is to use a Docker container in which a new ssh-agent is ran.  We advise the use of the https://github.com/10eTechnology/docker-ssh-agent-forward and have integrated this in the supplied scripts.  On mac, this solution is assumed to be installed.
+
+### NPM upgrades
+It's important to note that since NPM v7 peer dependencies are installed by default when executing `npm install`. As of v3.27 the docker-ember image contains NPM >= v7.x. Using this version may lead to resolution conflict errors on peer dependencies in existing projects. NPM provides a [`--legacy-peer-deps` flag](https://docs.npmjs.com/cli/v7/using-npm/config#legacy-peer-deps) to make `npm install` behave like in previous versions, not installing peer dependencies by default. This can help teams to gradually fix the peer dependency version conflicts in their project.
+
+The `--legacy-peer-deps` flag can be enabled project-wide by adding `legacy-peer-deps=true` to `.npmrc`. In that case it's import to copy that file inside your project's Docker build before running `npm install`.
+
+Example Dockerfile:
+```
+FROM madnificent/ember
+COPY package.json .
+COPY .npmrc .   # <--- this line must be added
+RUN npm install
+```
 
 ## Experimental features
 

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -1,14 +1,3 @@
-<<<<<<< HEAD
-FROM ubuntu:18.04
-MAINTAINER Aad Versteden <madnificent@gmail.com>
-
-# Install nodejs as per http://askubuntu.com/questions/672994/how-to-install-nodejs-4-on-ubuntu-15-04-64-bit-edition
-RUN apt-get -y update; apt-get -y install wget python build-essential git libfontconfig curl rsync
-RUN wget -qO- https://deb.nodesource.com/setup_10.x > node_setup.sh
-RUN bash node_setup.sh
-RUN apt-get -y install nodejs
-RUN npm install -g npm@6.9.0
-=======
 FROM ubuntu:21.04
 LABEL maintainer="Aad Versteden <madnificent@gmail.com>"
 
@@ -18,7 +7,6 @@ RUN wget -qO- https://deb.nodesource.com/setup_16.x > node_setup.sh
 RUN bash node_setup.sh
 RUN apt-get -y install nodejs
 RUN npm install -g npm@7.18.1
->>>>>>> madnificent/master
 # Install bower
 RUN npm install -g bower@1.8.12
 RUN echo '{ "allow_root": true }' > /root/.bowerrc
@@ -30,5 +18,3 @@ RUN apt-get update && apt-get -y install yarn
 RUN npm install -g ember-cli@@EMBER_VERSION
 
 WORKDIR /app
-
-

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -6,9 +6,9 @@ RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update; apt-get -y install
 RUN wget -qO- https://deb.nodesource.com/setup_16.x > node_setup.sh
 RUN bash node_setup.sh
 RUN apt-get -y install nodejs
-RUN npm install -g npm@7.18.1
+RUN npm install -g npm@8.3.0
 # Install bower
-RUN npm install -g bower@1.8.12
+RUN npm install -g bower@1.8.13
 RUN echo '{ "allow_root": true }' > /root/.bowerrc
 # Install yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -


### PR DESCRIPTION
Bumps the installed NPM version to v8.3 which has support for [overrides](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides) making dependency conflict resolution easier.

However, it's important to note that since NPM v7 peer dependencies are installed by default when executing `npm install`. This may lead to resolution conflict errors on peer dependencies in existing projects. NPM provides a [`--legacy-peer-deps` flag](https://docs.npmjs.com/cli/v7/using-npm/config#legacy-peer-deps) to make `npm install` behave like in previous versions, not installing peer dependencies by default (while still having support for the `overrides` feature of NPM v8.3). This can help teams to gradually fix the peer dependency version conflicts in their project.

The `--legacy-peer-deps` flag can be enabled project wide by adding `legacy-peer-deps=true` to `.npmrc`. In that case it's import to copy that file inside the Docker build before running `npm install`. 
Example Dockerfile:
```
FROM madnificent/ember
COPY package.json .
COPY .npmrc .   # <--- this line must be added
RUN npm install
```