### PR TITLE
bump base image to 22.04

### DIFF
--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -1,15 +1,13 @@
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 LABEL maintainer="Aad Versteden <madnificent@gmail.com>"
 
 # Install nodejs as per http://askubuntu.com/questions/672994/how-to-install-nodejs-4-on-ubuntu-15-04-64-bit-edition
-RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update; apt-get -y install wget python build-essential git libfontconfig curl rsync
+RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update; apt-get -y install wget python3 build-essential git libfontconfig curl rsync
 RUN wget -qO- https://deb.nodesource.com/setup_16.x > node_setup.sh
 RUN bash node_setup.sh
 RUN apt-get -y install nodejs
-RUN npm install -g npm@8.3.0
-# Install bower
-RUN npm install -g bower@1.8.13
-RUN echo '{ "allow_root": true }' > /root/.bowerrc
+RUN npm install -g npm@8.10.0
+
 # Install yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list


### PR DESCRIPTION
fixes #30

did some basic testing, running npm install in edi and running eds worked without issues.
NOTE: also bumps the npm minor version, but I don't think that's a requirement. can remove that if it's blocking