### PR TITLE
Updated Ubuntu 21.04 to 22.04, python2 to python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 LABEL maintainer="Aad Versteden <madnificent@gmail.com>"
 
 # Install nodejs as per http://askubuntu.com/questions/672994/how-to-install-nodejs-4-on-ubuntu-15-04-64-bit-edition
-RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update; apt-get -y install wget python build-essential git libfontconfig curl rsync
+RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update; apt-get -y install wget python3 build-essential git libfontconfig curl rsync
 RUN wget -qO- https://deb.nodesource.com/setup_16.x > node_setup.sh
 RUN bash node_setup.sh
 RUN apt-get -y install nodejs

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 LABEL maintainer="Aad Versteden <madnificent@gmail.com>"
 
 # Install nodejs as per http://askubuntu.com/questions/672994/how-to-install-nodejs-4-on-ubuntu-15-04-64-bit-edition
-RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update; apt-get -y install wget python build-essential git libfontconfig curl rsync
+RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update; apt-get -y install wget python3 build-essential git libfontconfig curl rsync
 RUN wget -qO- https://deb.nodesource.com/setup_16.x > node_setup.sh
 RUN bash node_setup.sh
 RUN apt-get -y install nodejs


### PR DESCRIPTION
Building the image using 21.04 seems to no longer be possible due to deprecated repositories
Thanks to @madnificent & @Riadabd !
Accidentally closed the previous PR because of my branch rename just ignore that