### PR TITLE
Detect docker-ember version from Dockerfile if present

### DIFF
--- a/support-scripts
+++ b/support-scripts
@@ -15,6 +15,16 @@ then
    fi
 fi
 
+# Find desired docker-ember version in Dockerfile
+edi_get_version_from_dockerfile() {
+  version_from_dockerfile=""
+  if [ -f Dockerfile ]
+  then
+    version_from_dockerfile=`cat Dockerfile | sed -E -n 's/FROM\smadnificent\/ember:(\S+)(\s+.*)?/\1/p'`
+  fi
+  echo $version_from_dockerfile
+}
+
 # Calculates the desired ember version based on the current settings.
 # EXPOSES $DOCKER_IMAGE
 edi_calculate_docker_image() {
@@ -22,6 +32,9 @@ edi_calculate_docker_image() {
     if [ -n "$EDI_EMBER_VERSION" ]
     then
         ember_version="$EDI_EMBER_VERSION"
+    elif [ -n "$(edi_get_version_from_dockerfile)" ]
+    then
+         ember_version="$(edi_get_version_from_dockerfile)"
     else
         ember_version="$VERSION"
     fi


### PR DESCRIPTION
When invoking `ed*` commands, check if the current directory has a Dockerfile that contains a `FROM madnificent/ember:x.y.z` statement. If so, use the extracted version for the `DOCKER_IMAGE` variable.

This behaviour can still be overriden by setting the `EDI_EMBER_VERSION` env var before invoking the `ed*` command.

I think this is useful when having to work on multiple frontends, some of which may use different Ember versions, so as to not have to keep track of which one to use. It's meant to emulate how nvm keeps track of which Node version to use per directory without having to add extra information (all our frontend repos should have Dockerfiles anyway).