### PR TITLE
Updated support-scripts edi_docker_host_option

### DIFF
--- a/support-scripts
+++ b/support-scripts
@@ -206,7 +206,7 @@ edi_does_container_exist() {
 }
 
 edi_docker_host_option() {
-    if [[ "$OSTYPE" == "linux-gnu" || "$OSTYPE" == "linux" ]]
+    if [[ "$OSTYPE" == "linux"* ]]
     then
         # Linux
         DOCKERHOST=`ip addr show docker0 | grep inet | head -n 1 | awk '{ print $2 }' | grep -oP "^[^/]+"`
@@ -214,9 +214,17 @@ edi_docker_host_option() {
         # Mac OSX
         # Solution found via https://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach
         DOCKERHOST=$(ifconfig | grep -E "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk '{ print $2 }' | cut -f2 -d: | head -n1)
-    else
-        echo "OS TYPE $OSTYPE not understood"
-        exit 1
+    fi
+
+    if [ -z "$DOCKERHOST" ]
+    then
+        # Normally echos would be used to not have all the info on one line in read -p,
+        # but considering that echo is used to build the command, that is not possible here.
+        default="172.17.0.1"
+        read -p $'Docker host could not be determined
+                  Please manually enter the IP of your docker0 bridge connection
+                  docker0 ip '"[$default]: " DOCKERHOST
+        DOCKERHOST=${DOCKERHOST:-$default}
     fi
     echo "--add-host host:$DOCKERHOST "
 }


### PR DESCRIPTION
- linux selector now uses a wildcard
- Added prompt for when dockerhost can't be automatically determined
  - the prompt will work both for other OS's,
  - as well as when the linux/darwin docker host IP getting fails

Thanks to @madnificent for the help!

(This PR replaces #34 as I completely goofed rebasing my previous branch)