### PR TITLE
add apply templates script 

### DIFF
--- a/apply-templates
+++ b/apply-templates
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+##
+# this script will apply templates in the repository to prepare for a docker build
+# note that the ember version defaults to the version used in "edi" when a version is not provided
+##
+
+# dont allow unset variables and exit on error
+set -ue
+
+if [[ "$OSTYPE" == "darwin"* ]]
+then
+    SCRIPT_FOLDER=`dirname "$(readlink "$0")"`
+else
+    SCRIPT_FOLDER=`dirname "$(readlink -f "$0")"`
+fi
+
+DEFAULT_VERSION_NUMBER=`grep "VERSION=" $SCRIPT_FOLDER/bin/edi | grep -oP "\\d+[^\"']+"`
+VERSION_NUMBER="${1:-$DEFAULT_VERSION_NUMBER}"
+
+pushd "$SCRIPT_FOLDER/templates"
+for file in `find . -type f`
+do
+    cp "$file" "../$file"
+    if [[ "$OSTYPE" == "darwin"* ]]
+    then
+        sed -i "" "s/@EMBER_VERSION/$VERSION_NUMBER/" ../$file
+        # https://stackoverflow.com/questions/6790631/use-the-contents-of-a-file-to-replace-a-string-using-sed
+        sed -i "" -e "/@SUPPORT_SCRIPTS/r ../support-scripts" -e "/@SUPPORT_SCRIPTS/d" ../$file
+    else
+        sed -i "s/@EMBER_VERSION/$VERSION_NUMBER/" ../$file
+        # https://stackoverflow.com/questions/6790631/use-the-contents-of-a-file-to-replace-a-string-using-sed
+        sed -i -e "/@SUPPORT_SCRIPTS/r ../support-scripts" -e "/@SUPPORT_SCRIPTS/d" ../$file
+    fi
+done

--- a/release
+++ b/release
@@ -48,21 +48,7 @@ fi
 
 if $(answerPositive "Create new files from template?")
 then
-    for file in `find . -type f`
-    do
-        cp "$file" "../$file"
-        if [[ "$OSTYPE" == "darwin"* ]]
-        then
-            sed -i "" "s/@EMBER_VERSION/$VERSION_NUMBER/" ../$file
-            # https://stackoverflow.com/questions/6790631/use-the-contents-of-a-file-to-replace-a-string-using-sed
-            sed -i "" -e "/@SUPPORT_SCRIPTS/r ../support-scripts" -e "/@SUPPORT_SCRIPTS/d" ../$file
-        else
-            sed -i "s/@EMBER_VERSION/$VERSION_NUMBER/" ../$file
-            # https://stackoverflow.com/questions/6790631/use-the-contents-of-a-file-to-replace-a-string-using-sed
-            sed -i -e "/@SUPPORT_SCRIPTS/r ../support-scripts" -e "/@SUPPORT_SCRIPTS/d" ../$file
-        fi
-
-    done
+    $SCRIPT_FOLDER/apply-templates $VERSION_NUMBER
 else
     echo "Not creating scripts...  exiting"
     exit 1;


### PR DESCRIPTION
~Currently templates are not applied in PRs or on master, but only on tags. I don't know the reasoning of this, but assume we want to keep it this way.~

~This PR fixes builds that happen on master and on PRs by adding a script to apply templates before we execute the build.~

extract a "apply-templates" script from the release script. This makes it easier for contributors to apply templates after making changes. The idea being that it's used when a PR is created that affects the templates