### PR TITLE
bump node to 18.16 and npm to 9.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ LABEL maintainer="Aad Versteden <madnificent@gmail.com>"
 
 # Install nodejs as per http://askubuntu.com/questions/672994/how-to-install-nodejs-4-on-ubuntu-15-04-64-bit-edition
 RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update; apt-get -y install wget python3 build-essential git libfontconfig curl rsync
-RUN wget -qO- https://deb.nodesource.com/setup_16.x > node_setup.sh
+RUN wget -qO- https://deb.nodesource.com/setup_18.x > node_setup.sh
 RUN bash node_setup.sh
 RUN apt-get -y install nodejs
-RUN npm install -g npm@8.10.0
+RUN npm install -g npm@9.6
 
 # Install yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -3,10 +3,10 @@ LABEL maintainer="Aad Versteden <madnificent@gmail.com>"
 
 # Install nodejs as per http://askubuntu.com/questions/672994/how-to-install-nodejs-4-on-ubuntu-15-04-64-bit-edition
 RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update; apt-get -y install wget python3 build-essential git libfontconfig curl rsync
-RUN wget -qO- https://deb.nodesource.com/setup_16.x > node_setup.sh
+RUN wget -qO- https://deb.nodesource.com/setup_18.x > node_setup.sh
 RUN bash node_setup.sh
 RUN apt-get -y install nodejs
-RUN npm install -g npm@8.10.0
+RUN npm install -g npm@9.6
 
 # Install yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -


### PR DESCRIPTION
basic testing on a 3.28 project seems to indicate this works and is a bit faster than node 16 and npm 8. 
Note: node 18 is only officially supported in ember as of ember 4 and this is yet to be tested on an ember 4 project