### PR TITLE
Replace link-to with LinkTo in README tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,13 @@ edi ember generate route hello-link
 
 Edit the *app/templates/hello-link.hbs* template so it contains the following
 ```hbs
-<p>Hello!  This is some nested content from my first page.  {{link-to 'Go back' 'index'}}</p>
+<p>Hello!  This is some nested content from my first page.  <LinkTo @route='index'>Go back</LinkTo></p>
 ```
 
 and add a link to *app/templates/application.hbs*
 ```hbs
 <h1>My first edi app</h1>
-<p>{{link-to 'Hello' 'hello-link'}}</p>
+<p><LinkTo @route='hello-link'>Hello</LinkTo></p>
 
 {{outlet}}
 ```


### PR DESCRIPTION
Angle bracket invocation syntax `<LinkTo>` available since Ember 3.10.

Curly braces syntax with positional arguments `{{link-to}}` deprecated since Ember 3.26 and removed in Ember 4.0.

https://blog.emberjs.com/ember-3-10-released/#toc_angle-bracket-invocation-for-built-in-components-2-of-4
https://github.com/emberjs/ember.js/blob/v5.2.0-alpha.2/CHANGELOG.md?plain=1#L842
https://deprecations.emberjs.com/v3.x/#toc_ember-glimmer-link-to-positional-arguments
https://github.com/emberjs/ember.js/blob/v5.2.0-alpha.2/CHANGELOG.md?plain=1#L392
https://github.com/emberjs/ember.js/blob/v5.2.0-alpha.2/CHANGELOG.md?plain=1#L219