### PR TITLE
Add support for rootless Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ There are some caveats with the use of edi.  First is configuring the ember vers
     Supported versions are the tags available at [https://hub.docker.com/r/madnificent/ember/tags/](https://hub.docker.com/r/madnificent/ember/tags/).
 
 - Linking to a backend
-    Each Docker Container is a mini virtual machine.  In this virtual machine, the name _localhost_ indicates that little virtual machine.  We have defined the name _host_ to link to the machine serving the application.  In case you’d setup a mu.semte.ch architecture backend, published on port 80 of your localhost, you could connect your development frontend to it as such:
+    Each Docker Container is a mini virtual machine.  In this virtual machine, the name _localhost_ indicates that little virtual machine.  `eds` gives two options for this, the `--add-host` option sets the name _host_ to link to the machine serving the application, `--network=some-docker-network` connects the virtual machine to a network defined by docker.  For example if you're using a [Semantic Works](https://semantic.works/) architecture backend, published on port 80 in a docker compose project called `my-project`, you could connect your development frontend to it as such:
 
     ```bash
-    eds --proxy http://host
+    eds --network=my-project_default --proxy http://identifier
     ```
 
     It is a common oversight to try to connect to localhost from the container instead.
@@ -237,7 +237,9 @@ non-interactive ember command.
     # No nonsense ember server
     eds
     # Proxying to your localhost (note it's been renamed from localhost to host)
-    eds --proxy=http://host:8080
+    eds --add-host --proxy=http://host:8080
+    # Proxying to a docker network
+    eds --network=network-name --proxy=http://service:8080
     # Serving on a non default port
     eds --port=4000 --live-reload-port=64000
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Supported versions are the tags available at [https://hub.docker.com/r/madnifice
 
 #### Linux configuration with user namespaces (advised)
 
-By default `ed*` commands run as root in the docker container, this means newly created files will be owned as root as well. To avoid this you can use user namespaces to map the container's root user to your own user. This requires some configuration and can be done with dockerd running as root (default) or as your user (see [Configuring on Linux (rootless)](#configuring-on-linux-rootless)).
+By default `ed*` commands run as root in the docker container, this means newly created files will be owned as root as well. To avoid this you can use user namespaces to map the container's root user to your own user. This requires some configuration and can be done with dockerd running as root (default) or as your user (see [Linux configuration with rootless docker](#linux-configuration-with-rootless-docker)).
 
 > [!NOTE]
 > on ubuntu 16.04 your user needs to part of the docker group so that it has access to `/var/run/docker.sock`
@@ -72,7 +72,7 @@ More information on user namespaces is available [in the docker documentation](h
 
 #### Linux configuration with rootless docker
 
-> [NOTE]
+> [!NOTE]
 > At this point we advise to use user namespaces instead, though if you have some experience with docker then rootless docker is a bright future.
 
 More recent versions of Docker can run in 'rootless' mode, running the docker daemon as a normal user instead of root. When running in this mode, the root user inside containers is always mapped to the host user, so no special `subuid` or `subgid` configuration are required. Users inside containers with uids >0 are mapped according to the `subuid` configuration.
@@ -225,20 +225,20 @@ root of your project.
 dependencies, install new ember dependencies and run any other
 non-interactive ember command.
 ```bash
-    # Install a dependency
-    ed ember install ember-cli-coffeescript
-    # Install all current node modules
-    ed npm install
-    # Install bower components
-    ed bower install
+# Install a dependency
+ed ember install ember-cli-coffeescript
+# Install all current node modules
+ed npm install
+# Install bower components
+ed bower install
  ```
 
 ### eds
 `eds` launches the ember server for you.
 
 ```bash
-    # No nonsense ember server
-    eds
+# No nonsense ember server
+eds
 ```
 
 #### Proxy to a local port (default)
@@ -250,39 +250,42 @@ Proxying is done to the special hostname `host` in this case, which will represe
 The Docker Container itself is a mini virtual machine.  In this virtual machine, the name _localhost_ indicates that little virtual machine.  For example if you're using a [Semantic Works](https://semantic.works/) architecture backend, published on port 80 in a docker compose project, you can connect your development frontend to it as such:
 
 ```bash
-    eds --proxy http://host/
+eds --proxy http://host/
 ```
 
 For instance, to proxy to port `8080` of the machine executing the command:
 
 ```bash
-    # Proxying to your localhost (note it's been renamed from localhost to host)
-    eds --proxy=http://host:8080/
+# Proxying to your localhost (note it's been renamed from localhost to host)
+eds --proxy=http://host:8080/
 ```
-> [NOTE]
+> [!NOTE]
 > The host to proxy to is `host` in this case, not `localhost`
 
-> [NOTE]
+> [!NOTE]
 > This makes use of the default `--add-host` option which may become optional in the future.  For scripting, you may want to run `eds --add-host --proxy=http://host:8080/` instead to be explicit.
 
 #### Proxy to a Docker Compose service (advanced)
 
 Proxying directly to a service in a Docker Compose stack without publishing ports.
 
+> [!NOTE]
+> The default option `--add-host` is disabled automatically when using this feature.
+
 Two parts need to be specified: the docker network where the service can be found, and which service to connect to in that network.  This does not require publishing a port locally.
 
 ```bash
-    # Proxying to a docker network
-    eds --network=network-name --proxy=http://service:8080
+# Proxying to a docker network
+eds --network=network-name --proxy=http://service:8080
 ```
 
 For example if you're using a [Semantic Works](https://semantic.works/) architecture backend, published on port 80 in a docker compose project called `my-project`, you could connect your development frontend to it as such:
 
 ```bash
-    eds --network=my-project_default --proxy http://identifier/
+eds --network=my-project_default --proxy http://identifier/
 ```
 
-> [NOTE]
+> [!NOTE]
 > This is the only supported method when running [Linux configuration with rootless docker](#linux-configuration-with-rootless-docker)
 
 #### Serving on a non default port
@@ -290,8 +293,8 @@ For example if you're using a [Semantic Works](https://semantic.works/) architec
 If port 4200 is already taken, `eds` can be ran on a different port.  Both `port` (which can be visited in the browser) as well as `live-reload-port` (for reloading on changes) need to be remapped.
 
 ```bash
-    # Serving on a non default port
-    eds --port=4000 --live-reload-port=64000
+# Serving on a non default port
+eds --port=4000 --live-reload-port=64000
 ```
 
 ### edi
@@ -299,34 +302,28 @@ If port 4200 is already taken, `eds` can be ran on a different port.  Both `port
 `edi` is the interactive version of `ed`.  It can ask you questions
 and you can provide interactive answers.
 ```bash
-    # Generate a route
-    edi ember generate route epic-win
-    # Release a new minor version
-    edi ember release --minor
+# Generate a route
+edi ember generate route epic-win
+# Release a new minor version
+edi ember release --minor
 ```
 
 ### edl
 `edl` is your friend when developing addons. It provides a replacement for `npm link` and `npm unlink` that works in docker-ember. 
 ```bash
-    # Create a global symlink of your addon
-    cd your-ember-addon
-    edl
-    # Use that addon in another project
-    cd your-ember-project
-    edl your-ember-addon
-    # Remove the global symlink of your addon
-    cd your-ember-addon
-    edl -u
+# Create a global symlink of your addon
+cd your-ember-addon
+edl
+# Use that addon in another project
+cd your-ember-project
+edl your-ember-addon
+# Remove the global symlink of your addon
+cd your-ember-addon
+edl -u
 ```
 
-> [NOTE]
+> [!NOTE]
 > `edl` assumes `edi` is available on your PATH
-
-### Proxy to the backend of a stack
-It is possible to use `eds` with a proxy to a microservice running in a local stack without port forwarding.
-
-> [NOTE]
-> The default option `--add-host` is disabled automatically when using this feature.
 
 ### Building locally
 

--- a/README.md
+++ b/README.md
@@ -177,19 +177,11 @@ There are some caveats with the use of edi.  First is configuring the ember vers
     You may want to have more than one ember version installed when generating new applications.  See [Picking an Ember Version](#picking-an-ember-version)
 
 - Linking to a backend
-    Multiple options exist for proxying to a backend.  When proxying to localhost use `--proxy=http://host/` instead of `--proxy=http://localhost/`.  See Proxy to a local port (default) and Proxy to a Docker Compose service (advanced) for your options.
+    Multiple options exist for proxying to a backend.  When proxying to localhost use `--proxy=http://host/` instead of `--proxy=http://localhost/`.  See [Proxy to a local port (default)](proxy-to-a-local-port-(default)) and [Proxy to a Docker Compose service (advanced)](proxy-to-a-docker-compose-service-(advanced)] for your options.
 
 And you're done! Our EmberJS development has become a lot more consistent and maintainable with the use of edi.  We have used it extensively, and have been able to reproduce builds easily in the past year.
 
 *This tutorial has been adapted from Aad Versteden's mu.semte.ch article. You can view it [here](https://mu.semte.ch/2017/03/09/developing-emberjs-with-docker/)*
-
-
-    Use `--proxy=http://host/`
-
-
-
-    It is a common oversight to try to connect to localhost from the container instead.
-
 
 ### Experimental features
 

--- a/README.md
+++ b/README.md
@@ -282,11 +282,17 @@ eds --network=network-name --proxy=http://service:8080
 For example if you're using a [Semantic Works](https://semantic.works/) architecture backend, published on port 80 in a docker compose project called `my-project`, you could connect your development frontend to it as such:
 
 ```bash
-eds --network=my-project_default --proxy http://identifier/
+eds --network=my-project_default --proxy=http://identifier/
 ```
 
 > [!NOTE]
 > This is the only supported method when running [Linux configuration with rootless docker](#linux-configuration-with-rootless-docker)
+
+#### Proxy to an external host
+
+To proxy to an external host use the `--proxy` option with no extra arguments. Some caveats exists:
+- if the backend uses HTTPS, specify the HTTPS url directly: `eds --proxy=https://semantic.works/`
+- with rootless docker you have to disable the docker network wiring using `-A` option: `eds -A --proxy=https://semantic.works/`
 
 #### Serving on a non default port
 

--- a/bin/ed
+++ b/bin/ed
@@ -250,26 +250,6 @@ edi_docker_host_option() {
     echo "--add-host host:$DOCKERHOST "
 }
 
-edi_docker_server_exposed_ports_option() {
-    for i in "$@"
-    do
-      case $i in
-        -p=*|--port=*)
-          EMBER_PORT="${i#*=}"
-        ;;
-        -lrp=*|--live-reload-port=*)
-          EMBER_LIVE_RELOAD_PORT="${i#*=}"
-        ;;
-        *)
-            # unknown option
-        ;;
-     esac
-   done
-
-    echo "-p ${EMBER_PORT:-4200}:${EMBER_PORT:-4200} \
-          -p ${EMBER_LIVE_RELOAD_PORT:-49152}:${EMBER_LIVE_RELOAD_PORT:-49152} "
-}
-
 #
 # END SUPPORT SCRIPTS
 #

--- a/bin/ed
+++ b/bin/ed
@@ -237,8 +237,13 @@ edi_does_container_exist() {
 edi_docker_host_option() {
     if [[ "$OSTYPE" == "linux-gnu" || "$OSTYPE" == "linux" ]]
     then
-        # Linux
+      # Linux
+      if ip addr show docker0 2>/dev/null 1>/dev/null
+      then
         DOCKERHOST=`ip addr show docker0 | grep inet | head -n 1 | awk '{ print $2 }' | grep -oP "^[^/]+"`
+      else
+        exit 1
+      fi
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         # Mac OSX
         # Solution found via https://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach

--- a/bin/edi
+++ b/bin/edi
@@ -235,8 +235,13 @@ edi_does_container_exist() {
 edi_docker_host_option() {
     if [[ "$OSTYPE" == "linux-gnu" || "$OSTYPE" == "linux" ]]
     then
-        # Linux
+      # Linux
+      if ip addr show docker0 2>/dev/null 1>/dev/null
+      then
         DOCKERHOST=`ip addr show docker0 | grep inet | head -n 1 | awk '{ print $2 }' | grep -oP "^[^/]+"`
+      else
+        exit 1
+      fi
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         # Mac OSX
         # Solution found via https://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach

--- a/bin/edi
+++ b/bin/edi
@@ -248,26 +248,6 @@ edi_docker_host_option() {
     echo "--add-host host:$DOCKERHOST "
 }
 
-edi_docker_server_exposed_ports_option() {
-    for i in "$@"
-    do
-      case $i in
-        -p=*|--port=*)
-          EMBER_PORT="${i#*=}"
-        ;;
-        -lrp=*|--live-reload-port=*)
-          EMBER_LIVE_RELOAD_PORT="${i#*=}"
-        ;;
-        *)
-            # unknown option
-        ;;
-     esac
-   done
-
-    echo "-p ${EMBER_PORT:-4200}:${EMBER_PORT:-4200} \
-          -p ${EMBER_LIVE_RELOAD_PORT:-49152}:${EMBER_LIVE_RELOAD_PORT:-49152} "
-}
-
 #
 # END SUPPORT SCRIPTS
 #

--- a/bin/eds
+++ b/bin/eds
@@ -248,33 +248,62 @@ edi_docker_host_option() {
     echo "--add-host host:$DOCKERHOST "
 }
 
-edi_docker_server_exposed_ports_option() {
-    for i in "$@"
-    do
-      case $i in
-        -p=*|--port=*)
-          EMBER_PORT="${i#*=}"
-        ;;
-        -lrp=*|--live-reload-port=*)
-          EMBER_LIVE_RELOAD_PORT="${i#*=}"
-        ;;
-        *)
-            # unknown option
-        ;;
-     esac
-   done
-
-    echo "-p ${EMBER_PORT:-4200}:${EMBER_PORT:-4200} \
-          -p ${EMBER_LIVE_RELOAD_PORT:-49152}:${EMBER_LIVE_RELOAD_PORT:-49152} "
-}
-
 #
 # END SUPPORT SCRIPTS
 #
 
 
 
+echo_help() {
+    echo "Serve an ember application within docker, optionally proxying to an api reachable on a docker network."
+    echo "Options:"
+    echo "-n=string|--network=string  connect the docker container to an existing docker network"
+    echo "-a|--add-host set a hostname 'host' inside the docker container that points to the host machine"
+    echo "-p=number|--port=number   serve the Ember app on given port"
+    echo "-lrp=number|--live-reload-port=number   port to use for live-reload websocket connection"
+    echo "-h|--help print this help"
+    echo "Any arguments other than --network and --add-host will be forwarded to the ember serve command"
+    echo "For backwards compatibility, not specifying --network implies --add-host"
+    echo "This may fail if you're using a rootless docker daemon"
+}
+
+for i in "$@"
+do
+  case $i in
+    -p=*|--port=*)
+        EMBER_PORT="${i#*=}"
+        EMBER_ARGS="$EMBER_ARGS $i"
+    ;;
+    -lrp=*|--live-reload-port=*)
+        EMBER_LIVE_RELOAD_PORT="${i#*=}"
+        EMBER_ARGS="$EMBER_ARGS $i"
+    ;;
+    -n=*|--network=*)
+        PROXY_NETWORK_OPTION="--network=${i#*=}"
+    ;;
+    -a|--add-host)
+        DOCKER_HOST_OPTION=$(edi_docker_host_option)
+    ;;
+    -h|--help)
+        echo_help
+        EMBER_ARGS="$EMBER_ARGS $i"
+    ;;
+    *)
+        # Unknown option, pass through to ember serve
+        EMBER_ARGS="$EMBER_ARGS $i"
+    ;;
+ esac
+done
+if [ -z "$PROXY_NETWORK_OPTION" ] && [ -z "$DOCKER_HOST_OPTION" ]
+then
+    echo "No --network specified, defaulting to adding a hostname in the container"
+    DOCKER_HOST_OPTION=$(edi_docker_host_option)
+fi
+
+EXPOSED_PORTS="-p ${EMBER_PORT:-4200}:${EMBER_PORT:-4200} \
+      -p ${EMBER_LIVE_RELOAD_PORT:-49152}:${EMBER_LIVE_RELOAD_PORT:-49152} "
+
 edi_calculate_docker_image # DOCKER_IMAGE
 edi_calculate_standard_docker_options # STANDARD_DOCKER_OPTIONS
 
-eval docker run --rm -it $STANDARD_DOCKER_OPTIONS `edi_docker_server_exposed_ports_option $@` `edi_docker_host_option ` $DOCKER_IMAGE ember serve $@
+eval docker run --rm -it $STANDARD_DOCKER_OPTIONS $EXPOSED_PORTS $DOCKER_HOST_OPTION $PROXY_NETWORK_OPTION $DOCKER_IMAGE ember serve $EMBER_ARGS

--- a/bin/eds
+++ b/bin/eds
@@ -284,9 +284,12 @@ do
     -a|--add-host)
         DOCKER_HOST_OPTION=$(edi_docker_host_option)
     ;;
+    -A|--no-add-host)
+        DOCKER_NO_HOST_OPTION=true
+    ;;
     -h|--help)
         echo_help
-        EMBER_ARGS="$EMBER_ARGS $i"
+        exit 0
     ;;
     *)
         # Unknown option, pass through to ember serve
@@ -294,9 +297,9 @@ do
     ;;
  esac
 done
-if [ -z "$PROXY_NETWORK_OPTION" ] && [ -z "$DOCKER_HOST_OPTION" ]
+if [ -z "$PROXY_NETWORK_OPTION" ] && [ -z "$DOCKER_HOST_OPTION" ] && [ -z "$DOCKER_NO_HOST_OPTION" ]
 then
-    echo "No --network specified, defaulting to adding a hostname in the container"
+    echo "No --network specified, defaulting to adding a hostname in the container. You can prevent this by passing --no-add-host or -A."
     DOCKER_HOST_OPTION=$(edi_docker_host_option)
 fi
 

--- a/bin/eds
+++ b/bin/eds
@@ -235,8 +235,13 @@ edi_does_container_exist() {
 edi_docker_host_option() {
     if [[ "$OSTYPE" == "linux-gnu" || "$OSTYPE" == "linux" ]]
     then
-        # Linux
+      # Linux
+      if ip addr show docker0 2>/dev/null 1>/dev/null
+      then
         DOCKERHOST=`ip addr show docker0 | grep inet | head -n 1 | awk '{ print $2 }' | grep -oP "^[^/]+"`
+      else
+        exit 1
+      fi
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         # Mac OSX
         # Solution found via https://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach
@@ -282,7 +287,7 @@ do
         PROXY_NETWORK_OPTION="--network=${i#*=}"
     ;;
     -a|--add-host)
-        DOCKER_HOST_OPTION=$(edi_docker_host_option)
+        DOCKER_FORCE_HOST_OPTION=true
     ;;
     -A|--no-add-host)
         DOCKER_NO_HOST_OPTION=true
@@ -297,10 +302,22 @@ do
     ;;
  esac
 done
-if [ -z "$PROXY_NETWORK_OPTION" ] && [ -z "$DOCKER_HOST_OPTION" ] && [ -z "$DOCKER_NO_HOST_OPTION" ]
+
+if [ -n "$DOCKER_FORCE_HOST_OPTION" ] && [ -n "$DOCKER_NO_HOST_OPTION" ]
 then
-    echo "No --network specified, defaulting to adding a hostname in the container. You can prevent this by passing --no-add-host or -A."
-    DOCKER_HOST_OPTION=$(edi_docker_host_option)
+  echo "-a and -A are mutually exclusive"
+  exit 1
+elif [ -n "$DOCKER_FORCE_HOST_OPTION" ] || ([ -z "$PROXY_NETWORK_OPTION" ] && [ -z "$DOCKER_FORCE_HOST_OPTION" ] && [ -z "$DOCKER_NO_HOST_OPTION" ])
+then
+  DOCKER_HOST_OPTION=$(edi_docker_host_option)
+  if [ $? -ne 0 ]
+  then
+    echo "Could not determine docker host network. Use -A or --no-add-host to explicitly disable setting the host."
+    exit 1
+  fi
+else
+  echo -n ""
+  # No need to calculate DOCKER_HOST_OPTION
 fi
 
 EXPOSED_PORTS="-p ${EMBER_PORT:-4200}:${EMBER_PORT:-4200} \

--- a/support-scripts
+++ b/support-scripts
@@ -221,8 +221,13 @@ edi_does_container_exist() {
 edi_docker_host_option() {
     if [[ "$OSTYPE" == "linux-gnu" || "$OSTYPE" == "linux" ]]
     then
-        # Linux
+      # Linux
+      if ip addr show docker0 2>/dev/null 1>/dev/null
+      then
         DOCKERHOST=`ip addr show docker0 | grep inet | head -n 1 | awk '{ print $2 }' | grep -oP "^[^/]+"`
+      else
+        exit 1
+      fi
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         # Mac OSX
         # Solution found via https://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach

--- a/support-scripts
+++ b/support-scripts
@@ -234,26 +234,6 @@ edi_docker_host_option() {
     echo "--add-host host:$DOCKERHOST "
 }
 
-edi_docker_server_exposed_ports_option() {
-    for i in "$@"
-    do
-      case $i in
-        -p=*|--port=*)
-          EMBER_PORT="${i#*=}"
-        ;;
-        -lrp=*|--live-reload-port=*)
-          EMBER_LIVE_RELOAD_PORT="${i#*=}"
-        ;;
-        *)
-            # unknown option
-        ;;
-     esac
-   done
-
-    echo "-p ${EMBER_PORT:-4200}:${EMBER_PORT:-4200} \
-          -p ${EMBER_LIVE_RELOAD_PORT:-49152}:${EMBER_LIVE_RELOAD_PORT:-49152} "
-}
-
 #
 # END SUPPORT SCRIPTS
 #

--- a/templates/bin/eds
+++ b/templates/bin/eds
@@ -44,7 +44,7 @@ do
         PROXY_NETWORK_OPTION="--network=${i#*=}"
     ;;
     -a|--add-host)
-        DOCKER_HOST_OPTION=$(edi_docker_host_option)
+        DOCKER_FORCE_HOST_OPTION=true
     ;;
     -A|--no-add-host)
         DOCKER_NO_HOST_OPTION=true
@@ -59,10 +59,22 @@ do
     ;;
  esac
 done
-if [ -z "$PROXY_NETWORK_OPTION" ] && [ -z "$DOCKER_HOST_OPTION" ] && [ -z "$DOCKER_NO_HOST_OPTION" ]
+
+if [ -n "$DOCKER_FORCE_HOST_OPTION" ] && [ -n "$DOCKER_NO_HOST_OPTION" ]
 then
-    echo "No --network specified, defaulting to adding a hostname in the container. You can prevent this by passing --no-add-host or -A."
-    DOCKER_HOST_OPTION=$(edi_docker_host_option)
+  echo "-a and -A are mutually exclusive"
+  exit 1
+elif [ -n "$DOCKER_FORCE_HOST_OPTION" ] || ([ -z "$PROXY_NETWORK_OPTION" ] && [ -z "$DOCKER_FORCE_HOST_OPTION" ] && [ -z "$DOCKER_NO_HOST_OPTION" ])
+then
+  DOCKER_HOST_OPTION=$(edi_docker_host_option)
+  if [ $? -ne 0 ]
+  then
+    echo "Could not determine docker host network. Use -A or --no-add-host to explicitly disable setting the host."
+    exit 1
+  fi
+else
+  echo -n ""
+  # No need to calculate DOCKER_HOST_OPTION
 fi
 
 EXPOSED_PORTS="-p ${EMBER_PORT:-4200}:${EMBER_PORT:-4200} \

--- a/templates/bin/eds
+++ b/templates/bin/eds
@@ -16,7 +16,56 @@ fi
 
 
 
+echo_help() {
+    echo "Serve an ember application within docker, optionally proxying to an api reachable on a docker network."
+    echo "Options:"
+    echo "-n=string|--network=string  connect the docker container to an existing docker network"
+    echo "-a|--add-host set a hostname 'host' inside the docker container that points to the host machine"
+    echo "-p=number|--port=number   serve the Ember app on given port"
+    echo "-lrp=number|--live-reload-port=number   port to use for live-reload websocket connection"
+    echo "-h|--help print this help"
+    echo "Any arguments other than --network and --add-host will be forwarded to the ember serve command"
+    echo "For backwards compatibility, not specifying --network implies --add-host"
+    echo "This may fail if you're using a rootless docker daemon"
+}
+
+for i in "$@"
+do
+  case $i in
+    -p=*|--port=*)
+        EMBER_PORT="${i#*=}"
+        EMBER_ARGS="$EMBER_ARGS $i"
+    ;;
+    -lrp=*|--live-reload-port=*)
+        EMBER_LIVE_RELOAD_PORT="${i#*=}"
+        EMBER_ARGS="$EMBER_ARGS $i"
+    ;;
+    -n=*|--network=*)
+        PROXY_NETWORK_OPTION="--network=${i#*=}"
+    ;;
+    -a|--add-host)
+        DOCKER_HOST_OPTION=$(edi_docker_host_option)
+    ;;
+    -h|--help)
+        echo_help
+        EMBER_ARGS="$EMBER_ARGS $i"
+    ;;
+    *)
+        # Unknown option, pass through to ember serve
+        EMBER_ARGS="$EMBER_ARGS $i"
+    ;;
+ esac
+done
+if [ -z "$PROXY_NETWORK_OPTION" ] && [ -z "$DOCKER_HOST_OPTION" ]
+then
+    echo "No --network specified, defaulting to adding a hostname in the container"
+    DOCKER_HOST_OPTION=$(edi_docker_host_option)
+fi
+
+EXPOSED_PORTS="-p ${EMBER_PORT:-4200}:${EMBER_PORT:-4200} \
+      -p ${EMBER_LIVE_RELOAD_PORT:-49152}:${EMBER_LIVE_RELOAD_PORT:-49152} "
+
 edi_calculate_docker_image # DOCKER_IMAGE
 edi_calculate_standard_docker_options # STANDARD_DOCKER_OPTIONS
 
-eval docker run --rm -it $STANDARD_DOCKER_OPTIONS `edi_docker_server_exposed_ports_option $@` `edi_docker_host_option ` $DOCKER_IMAGE ember serve $@
+eval docker run --rm -it $STANDARD_DOCKER_OPTIONS $EXPOSED_PORTS $DOCKER_HOST_OPTION $PROXY_NETWORK_OPTION $DOCKER_IMAGE ember serve $EMBER_ARGS

--- a/templates/bin/eds
+++ b/templates/bin/eds
@@ -46,9 +46,12 @@ do
     -a|--add-host)
         DOCKER_HOST_OPTION=$(edi_docker_host_option)
     ;;
+    -A|--no-add-host)
+        DOCKER_NO_HOST_OPTION=true
+    ;;
     -h|--help)
         echo_help
-        EMBER_ARGS="$EMBER_ARGS $i"
+        exit 0
     ;;
     *)
         # Unknown option, pass through to ember serve
@@ -56,9 +59,9 @@ do
     ;;
  esac
 done
-if [ -z "$PROXY_NETWORK_OPTION" ] && [ -z "$DOCKER_HOST_OPTION" ]
+if [ -z "$PROXY_NETWORK_OPTION" ] && [ -z "$DOCKER_HOST_OPTION" ] && [ -z "$DOCKER_NO_HOST_OPTION" ]
 then
-    echo "No --network specified, defaulting to adding a hostname in the container"
+    echo "No --network specified, defaulting to adding a hostname in the container. You can prevent this by passing --no-add-host or -A."
     DOCKER_HOST_OPTION=$(edi_docker_host_option)
 fi
 


### PR DESCRIPTION
This now works by adding an option to `eds` to connect the container to a docker network. There's also an option to use the existing behaviour, for backwards compatibility, this is used by default if the network option isn't used. I've updated the readme to show the new usage.