### PR TITLE
Use jq for extracting properties from json

### DIFF
--- a/bin/edl
+++ b/bin/edl
@@ -13,8 +13,7 @@ mkdir -p $NODE_M_PATH
 
 # supporting function to extract json values
 function jsonval {
-    temp=`echo $json | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w $prop | cut -d":" -f2| sed -e 's/^ *//g' -e 's/ *$//g' `
-    echo ${temp##*|}
+    echo "$json" | jq -r ".$prop"
 }
 
 # check if a string starts with provided value


### PR DESCRIPTION
The current way of parsing the json name may yield false positives
creating an incorrect link through `edl`.

Assuming jq is commonly available, if not then we should run this
processing inside of a container with everything we need on board.  It
is not clear to me whether we can/should depend on `jq` being installed.
mu-cli runs this through a Docker Container but we did not research the
need for `jq` specifically.