### PR TITLE
Add support for corepack

### DIFF
--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -9,6 +9,7 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesourc
 RUN apt-get -y update && apt-get -y install nodejs
 
 # Enable corepack
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable
 
 # Install ember-cli

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -8,10 +8,8 @@ RUN mkdir -p /etc/apt/keyrings && curl -fsSL https://deb.nodesource.com/gpgkey/n
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
 RUN apt-get -y update && apt-get -y install nodejs
 
-# Install yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get -y install yarn
+# Enable corepack
+RUN corepack enable
 
 # Install ember-cli
 RUN npm install -g ember-cli@@EMBER_VERSION


### PR DESCRIPTION
### Overview
This PR includes support for [corepack](https://nodejs.org/api/corepack.html). Corepack is a tool to easily manage package managers like `pnpm` and `yarn`. It also allows you to manage different versions of these package managers.

By enabling corepack support, it should be straightforward for a user to utilize both `pnpm` and `yarn`. The package manager/version that is used depends on the `packageManager` field of the `package.json` file (https://nodejs.org/api/packages.html#packagemanager).


### How to test/reproduce
- Run the release script to build a local version of `docker-ember`
- Run the `edi` command and ensure you have access to both `pnpm` and `yarn`
- The version of the package manager should depend on your `packageManager` setting. Otherwise, the latest stable version should be used.
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
Unsure if we should set `COREPACK_ENABLE_DOWNLOAD_PROMPT` to 0. This environment variable controls whether a prompt is shown if the packagemanager version is not yet installed.
