### PR TITLE
feat: use the more portable /usr/bin/env

### DIFF
--- a/release
+++ b/release
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Help information
 if [ "$#" -eq 0 ]

--- a/templates/bin/ed
+++ b/templates/bin/ed
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This is the standard command to use when running non-interactive commands
 # eg:
 #   ed ember generate model post

--- a/templates/bin/edi
+++ b/templates/bin/edi
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This is the command to use when running interactive commands
 # eg:
 #   edi ember release --minor

--- a/templates/bin/eds
+++ b/templates/bin/eds
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This is the command to use when running interactive commands
 # eg:
 #   edi ember release --minor


### PR DESCRIPTION
Some systems (nixos being a notable example) do not have bash in their /usr/bin
While /usr/bin/env is not a perfect solution, it does tend to be more portable. It will find bash no matter where it is, as long as it's available in your path.

Note the `apply-templates` script was already using this form, this PR just extends it to all templates and scripts.

The equivalent PR on mu-cli was merged a while ago: https://github.com/mu-semtech/mu-cli/pull/19 
So it seems to have survived a few years of usage without any complaints