### PR TITLE
Install ember-cli-update globally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,7 @@ RUN apt-get update && apt-get -y install yarn
 # Install ember-cli
 RUN npm install -g ember-cli@5.12.0
 
+# Install ember-cli-update
+RUN npm install -g ember-cli-update
+
 WORKDIR /app


### PR DESCRIPTION
Allows to easily update Ember apps using `edi ember-cli-update` without installing ember-cli-update as a project dependency.